### PR TITLE
congestion window, able to reliably send 50 KB

### DIFF
--- a/code/tcp-v2/bytestream.h
+++ b/code/tcp-v2/bytestream.h
@@ -23,8 +23,7 @@
 #define MAX(a, b) ((a) > (b) ? (a) : (b))
 
 /* Buffer capacity constants */
-#define MAX_WINDOW_SIZE 1024
-#define BS_CAPACITY MAX_WINDOW_SIZE
+#define BS_CAPACITY 2048
 
 /**
  * Bytestream structure - circular buffer implementation

--- a/code/tcp-v2/code-gen-src/byte-array-small-file.h
+++ b/code/tcp-v2/code-gen-src/byte-array-small-file.h
@@ -11513,4 +11513,4 @@ static const uint8_t binary_data[] = {
 };
 
 // Size of the binary data
-static const size_t binary_length = 92079;
+static const size_t binary_length = 50000;

--- a/code/tcp-v2/rcp-header.h
+++ b/code/tcp-v2/rcp-header.h
@@ -92,7 +92,7 @@ static inline uint8_t rcp_calculate_checksum(const rcp_header_t *hdr, const uint
     temp_hdr.cksum = 0;
 
     // Use 16-bit one's complement sum
-    uint16_t sum = 0;
+    size_t sum = 0;
     const uint8_t *data = (const uint8_t *)&temp_hdr;
 
     // Sum header bytes as 16-bit words

--- a/code/tcp-v2/receiver.h
+++ b/code/tcp-v2/receiver.h
@@ -3,6 +3,9 @@
 #include "bytestream.h"
 #include "types.h"
 
+// Receiver's window size
+#define MAX_WINDOW_SIZE 64
+
 /********* TYPES *********/
 
 /* Receiver state structure */

--- a/code/tcp-v2/sender.h
+++ b/code/tcp-v2/sender.h
@@ -6,7 +6,11 @@
 /********* TYPES *********/
 
 /* Initial window size and timeout constants */
-#define INITIAL_WINDOW_SIZE 1024
+#define INITIAL_WINDOW_SIZE 256
+#define MS_TO_US(ms) ((ms) * 1000)
+#define MIN_CWND (4 * RCP_MAX_PAYLOAD)        /* Minimum congestion window size */
+#define MAX_CWND (64 * RCP_MAX_PAYLOAD)       /* Maximum congestion window size */
+#define CWND_THRESHOLD (16 * RCP_MAX_PAYLOAD) /* Threshold to exit slow start */
 
 /* Sender state structure */
 typedef struct sender {
@@ -16,6 +20,13 @@ typedef struct sender {
     uint16_t next_seqno;  /* Next sequence number to send */
     uint16_t acked_seqno; /* Sequence number of the highest acked segment */
     uint16_t window_size; /* Receiver's advertised window size */
+
+    /* Congestion control fields */
+    uint16_t cwnd;              /* Congestion window size in bytes */
+    uint8_t dup_ack_count;      /* Count of duplicate ACKs */
+    bool in_slow_start;         /* Whether in slow start or congestion avoidance */
+    uint32_t last_send_time;    /* Time of last segment sent */
+    uint32_t min_send_interval; /* Minimum interval between sends */
 } sender_t;
 
 /********* SENDER *********/
@@ -35,6 +46,13 @@ static inline sender_t sender_init(uint8_t local_addr, uint8_t remote_addr) {
         .window_size = INITIAL_WINDOW_SIZE,
         .local_addr = local_addr,
         .remote_addr = remote_addr,
+
+        /* Initialize congestion control */
+        .cwnd = MIN_CWND, /* Start with 2 segments */
+        .dup_ack_count = 0,
+        .in_slow_start = true,
+        .last_send_time = 0,
+        .min_send_interval = MS_TO_US(1) /* 1ms initial pacing */
     };
     return sender;
 }
@@ -75,9 +93,11 @@ static inline sender_segment_t make_segment(sender_t *sender, size_t len) {
  *
  * @param sender The sender to update
  * @param segment The segment that was sent
+ * @param current_time_us Current time in microseconds
  * @return True if state updated successfully
  */
-static inline bool sender_segment_sent(sender_t *sender, sender_segment_t *segment) {
+static inline bool sender_segment_sent(sender_t *sender, sender_segment_t *segment,
+                                       uint32_t current_time_us) {
     assert(sender);
     assert(segment);
 
@@ -92,9 +112,25 @@ static inline bool sender_segment_sent(sender_t *sender, sender_segment_t *segme
         if (segment->is_syn || segment->is_fin) {
             sender->next_seqno++;
         }
+
+        // Update last send time
+        sender->last_send_time = current_time_us;
     }
 
     return true;
+}
+
+/**
+ * Check if it's too soon to send another segment
+ *
+ * @param sender The sender to check
+ * @param current_time_us Current time in microseconds
+ * @return True if we should wait, false if ok to send
+ */
+static inline bool sender_should_wait(sender_t *sender, uint32_t current_time_us) {
+    assert(sender);
+
+    return (current_time_us < sender->last_send_time + sender->min_send_interval);
 }
 
 /**
@@ -102,6 +138,7 @@ static inline bool sender_segment_sent(sender_t *sender, sender_segment_t *segme
  *
  * @param sender The sender to process the reply for
  * @param reply The reply segment from the receiver
+ * @return A pointer to a segment that should be retransmitted, or NULL if none
  */
 static inline void sender_process_ack(sender_t *sender, receiver_segment_t *reply) {
     assert(sender);
@@ -113,8 +150,50 @@ static inline void sender_process_ack(sender_t *sender, receiver_segment_t *repl
             return;
         }
 
-        // Update highest acknowledged sequence number
-        sender->acked_seqno = reply->ackno;
+        if (reply->ackno > sender->acked_seqno) {
+            // New data acknowledged
+            uint16_t bytes_acked = reply->ackno - sender->acked_seqno;
+            sender->acked_seqno = reply->ackno;
+
+            // Update congestion window
+            if (sender->in_slow_start) {
+                // Exponential increase during slow start
+                sender->cwnd += MIN(bytes_acked, RCP_MAX_PAYLOAD);
+
+                // Exit slow start if cwnd exceeds threshold
+                if (sender->cwnd >= CWND_THRESHOLD) {
+                    sender->in_slow_start = false;
+                }
+            } else {
+                // Additive increase during congestion avoidance - about 1 segment per RTT
+                // printk("Adding %u to cwnd\n", (RCP_MAX_PAYLOAD * bytes_acked) / sender->cwnd);
+                sender->cwnd++;
+            }
+
+            // Cap the congestion window to avoid overflow
+            if (sender->cwnd > MAX_CWND) {
+                sender->cwnd = MAX_CWND;
+            }
+
+            // Reset duplicate ACK counter
+            sender->dup_ack_count = 0;
+
+            // Allow sending more frequently now
+            sender->min_send_interval = MAX(sender->min_send_interval / 2, MS_TO_US(0.5));
+        } else if (reply->ackno == sender->acked_seqno) {
+            // Duplicate ACK received
+            sender->dup_ack_count++;
+
+            // Fast retransmit after 3 duplicate ACKs
+            if (sender->dup_ack_count == 3) {
+                // Cut congestion window in half
+                sender->cwnd = MAX(sender->cwnd / 2, MIN_CWND);
+                sender->in_slow_start = false;
+
+                // Reset the counter - we'll handle actual retransmit in tcp.h
+                sender->dup_ack_count = 0;
+            }
+        }
     }
 
     // Update window size from receiver
@@ -122,12 +201,14 @@ static inline void sender_process_ack(sender_t *sender, receiver_segment_t *repl
 }
 
 /**
- * Generate the next segment to send (if any)
+ * Generate the next segment to send if any
  *
  * @param sender The sender to generate a segment from
+ * @param current_time_us Current time in microseconds
  * @return A pointer to the generated segment, or NULL if none
  */
-static inline sender_segment_t *sender_generate_segment(sender_t *sender) {
+static inline sender_segment_t *sender_generate_segment(sender_t *sender,
+                                                        uint32_t current_time_us) {
     assert(sender);
 
     static sender_segment_t next_segment;
@@ -140,6 +221,24 @@ static inline sender_segment_t *sender_generate_segment(sender_t *sender) {
     DEBUG_PRINT("      - bs_bytes_available(&sender->reader): %u\n",
                 bs_bytes_available(&sender->reader));
 
+    // Don't send if too soon after last send
+    if (sender_should_wait(sender, current_time_us)) {
+        return NULL;
+    }
+
+    // Calculate bytes in flight
+    uint16_t bytes_in_flight = sender->next_seqno - sender->acked_seqno;
+
+    // Don't send if we've hit congestion window limit
+    if (bytes_in_flight >= sender->cwnd) {
+        return NULL;
+    }
+
+    // Don't send if receiver window is full
+    if (bytes_in_flight >= sender->window_size) {
+        return NULL;
+    }
+
     // If FIN has been sent, no more data can be pushed
     if (bs_reader_finished(&sender->reader) &&
         (sender->next_seqno > bs_bytes_popped(&sender->reader) + 1)) {
@@ -147,24 +246,19 @@ static inline sender_segment_t *sender_generate_segment(sender_t *sender) {
         return NULL;
     }
 
-    // Edge case: if receiver window is 0, send a probe segment
-    if (sender->window_size == 0) {
-        // Send a zero-length segment to probe for window update
+    // Determine remaining window space
+    uint16_t effective_window = MIN(sender->cwnd, sender->window_size);
+    uint16_t remaining_window = effective_window - bytes_in_flight;
+
+    // Edge case: if effective window is 0, send probe segment for window update
+    if (effective_window == 0 && sender->window_size == 0) {
         next_segment = make_segment(sender, 0);
         return &next_segment;
     }
 
-    // Check if receiver has enough space to receive more data
-    uint32_t receiver_max_seqno = sender->acked_seqno + sender->window_size;
-    if (receiver_max_seqno <= sender->next_seqno) {
-        // No space in receiver window
-        return NULL;
-    }
-
     // Send data if available in the bytestream
-    if (bs_bytes_available(&sender->reader)) {
-        uint32_t remaining_space = receiver_max_seqno - sender->next_seqno;
-        next_segment = make_segment(sender, remaining_space);
+    if (bs_bytes_available(&sender->reader) && remaining_window > 0) {
+        next_segment = make_segment(sender, remaining_window);
         return &next_segment;
     } else if (bs_reader_finished(&sender->reader)) {
         // If bytestream is finished and we haven't sent FIN yet, send it
@@ -176,6 +270,24 @@ static inline sender_segment_t *sender_generate_segment(sender_t *sender) {
     }
 
     return NULL;
+}
+
+/**
+ * Handle a retransmission event
+ *
+ * @param sender The sender to update
+ * @param seqno The sequence number being retransmitted
+ * @param current_time_us Current time in microseconds
+ */
+static inline void sender_handle_retransmit(sender_t *sender, uint16_t seqno) {
+    assert(sender);
+
+    // Reduce congestion window
+    sender->cwnd = MAX(sender->cwnd / 2, MIN_CWND);
+    sender->in_slow_start = false;
+
+    // Increase pacing interval to slow down sending
+    sender->min_send_interval = MIN(sender->min_send_interval * 2, MS_TO_US(10));
 }
 
 /**
@@ -196,4 +308,24 @@ static inline bool sender_is_done(sender_t *sender) {
 
     // If stream not finished, sender is only done if there's no data pending
     return bs_bytes_available(&sender->reader) == 0 && sender->acked_seqno == sender->next_seqno;
+}
+
+/**
+ * Get the current congestion window information
+ *
+ * @param sender The sender to check
+ * @param cwnd_out Pointer to store the congestion window
+ * @param bytes_in_flight_out Pointer to store bytes in flight
+ */
+static inline void sender_get_cwnd_info(sender_t *sender, uint16_t *cwnd_out,
+                                        uint16_t *bytes_in_flight_out) {
+    assert(sender);
+
+    if (cwnd_out) {
+        *cwnd_out = sender->cwnd;
+    }
+
+    if (bytes_in_flight_out) {
+        *bytes_in_flight_out = sender->next_seqno - sender->acked_seqno;
+    }
 }


### PR DESCRIPTION
1024 window size with cwnd:
- https://gist.github.com/jackle3/8702ef0e0245dd0e35353e56be40f848
- throughput is 50kb / 184 sec = 0.2717391304 kB/s

64 window sizes with cwnd:
- https://gist.github.com/jackle3/d97c8f12e4edbfcadc9988bad5f0d395
- throughput is 50kb / 93 sec = 0.5376344086 kB/s

64 window size without cwnd:
- https://gist.github.com/jackle3/d5fb7ef1c863f81f2779369354077e2c
- throughput is 20kb / 18 sec = 1.1111111111 kB/s

also ran into the issue of the seqno wrapping around in very large files
- https://gist.github.com/jackle3/0b628df814dda97b996ac7151d9d52cc

this is what claude has to say:

Key findings:
- Smaller window size (64 vs 1024) improved throughput by approximately 2x
- Removing congestion control with the 64 window size further doubled throughput
- Sequence number wrapping occurs with large file transfers, requiring careful handling

Conclusion: For this resource-constrained NRF environment, traditional TCP congestion 
control mechanisms appear to create unnecessary overhead. A smaller fixed window size 
without congestion control provides significantly better performance (4x improvement) 
by preventing buffer overflow while reducing protocol complexity. This approach better 
matches the limited processing capabilities and memory constraints of the NRF hardware.